### PR TITLE
Update Snowflake URL for spark connector

### DIFF
--- a/hq.py
+++ b/hq.py
@@ -216,10 +216,10 @@ def main() -> None:
             "host": "10.255.2.5",
             "port": "1433",
             "database": "HQ_QLT",
-            "username": dbutils.secrets.get(
+            "username": dbutils.secrets.get(  # noqa: F821
                 scope="key-vault-secret", key="DataProduct-SB-HQ-User"
             ),
-            "password": dbutils.secrets.get(
+            "password": dbutils.secrets.get(  # noqa: F821
                 scope="key-vault-secret", key="DataProduct-SB-HQ-Pass"
             ),
         }
@@ -230,11 +230,11 @@ def main() -> None:
         }
 
         snowflake_config = {
-            "sfURL": "https://hmkovlx-nu26765.snowflakecomputing.com",
-            "sfUser": dbutils.secrets.get(
+            "sfURL": "hmkovlx-nu26765.snowflakecomputing.com",
+            "sfUser": dbutils.secrets.get(  # noqa: F821
                 scope="key-vault-secret", key="DataProduct-SF-EDW-User"
             ),
-            "sfPassword": dbutils.secrets.get(
+            "sfPassword": dbutils.secrets.get(  # noqa: F821
                 scope="key-vault-secret", key="DataProduct-SF-EDW-Pass"
             ),
             "sfDatabase": "DEV",

--- a/tests/test_snowflake_connection.py
+++ b/tests/test_snowflake_connection.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+import snowflake.connector
+
+
+def test_connect_without_scheme():
+    user = os.getenv('SF_USER')
+    password = os.getenv('SF_PASSWORD')
+    if not user or not password:
+        pytest.skip('SF_USER and SF_PASSWORD environment variables not set')
+
+    try:
+        snowflake.connector.connect(
+            user=user,
+            password=password,
+            account='hmkovlx-nu26765',
+            host='hmkovlx-nu26765.snowflakecomputing.com',
+            warehouse='COMPUTE_WH',
+            database='DEV',
+            schema='PUBLIC',
+        )
+    except snowflake.connector.errors.Error as e:
+        pytest.fail(f'Authentication failed: {e}')


### PR DESCRIPTION
## Summary
- remove scheme from `sfURL` configuration
- add a simple connection test verifying host-only URLs
- suppress linter errors on `dbutils` references

## Testing
- `ruff check hq.py tests/test_snowflake_connection.py`
- `python -m py_compile hq.py tests/test_snowflake_connection.py`
- `pytest -q tests/test_snowflake_connection.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d4abb3908325bff15ed0d2a67296